### PR TITLE
Corrects SessionData `meeting` Param Default

### DIFF
--- a/api/src/store.py
+++ b/api/src/store.py
@@ -12,7 +12,7 @@ class SessionData:
     def __init__(self,
                  drivers: dict = {"session_key": []},
                  laps: dict = {"session_key": []},
-                 meetings: dict = {"session_key": []},
+                 meetings: dict = {"year": []},
                  radios: dict = {"session_key": []},
                  sessions: dict = {"session_key": []},
                  session_key: int = 0,

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -51,7 +51,7 @@ def test_get_available_races_by_year(mock_available_races_by_year,
                                      override_get_app_session_data):
 
     expected_call_kwargs = {
-        "meetings_df": pd.DataFrame({"session_key": []}),
+        "meetings_df": pd.DataFrame({"year": []}),
         "year": 2024
     }
 
@@ -88,7 +88,7 @@ def test_get_participating_drivers(mock_participating_drivers,
 
     expected_call_kwargs = {
         "drivers_df": pd.DataFrame({"session_key": []}),
-        "meetings_df": pd.DataFrame({"session_key": []}),
+        "meetings_df": pd.DataFrame({"year": []}),
         "sessions_df": pd.DataFrame({"session_key": []}),
         "year": 2023,
         "current_session_key": 0,


### PR DESCRIPTION
*quick fix* 😅 
Changes to the meeting default dict key had to be made for successful downstream dataframe merging, i.e. in `available_races_by_year` L-26.