### PR TITLE
Fixes NaN Value Cases in Lap Data

### DIFF
--- a/api/src/service.py
+++ b/api/src/service.py
@@ -166,6 +166,9 @@ def _set_radio_lap_numbers(radios_df: pd.DataFrame, laps_df: pd.DataFrame):
                               left_on="date",
                               right_on="date_start")
                               .rename(columns={"date_start": "lap_date_start"}))
+
+    radios_df["lap_number"] = radios_df["lap_number"].fillna(0)
+    radios_df["lap_date_start"] = radios_df["lap_date_start"].fillna(radios_df["date"])
     return radios_df
 
 


### PR DESCRIPTION
 Added corrective measures to fill in missing `lap_number` and `lap_date_start` when `pandas.merge_as_of()` is unable to find a match.
I default to a lap number of `0` to fill, and the respective radio time in the row for the lap start time.

RE: #6